### PR TITLE
Add force parameter to allow specific version to be installed.

### DIFF
--- a/update_ombi.sh
+++ b/update_ombi.sh
@@ -58,11 +58,23 @@ SECONDS=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --verbosity|-v=*)
+      shift
       if [[ ${1#*=} =~ ^-?[0-8]$ ]]; then
           verbosity="${1#*=}"
       else
           printf "****************************\n"
           printf "* Error: Invalid verbosity.*\n"
+          printf "****************************\n"
+          exit 1
+      fi
+      ;;
+    --force|-f=*)
+      shift
+      if [[ ${1#*=} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          force="${1#*=}"
+      else
+          printf "****************************\n"
+          printf "* Error: Invalid version.  *\n"
           printf "****************************\n"
           exit 1
       fi
@@ -181,6 +193,10 @@ do
     .log 8 "json: $json"
     latestversion=$(grep -Po '(?<="updateVersionString":")([^"]+)' <<<  "$json")
     .log 7 "latestversion: $latestversion"
+    if [ -n "$force" ]; then
+        latestversion=$force
+        .log 7 "forcing version: $latestversion"
+    fi
     json=$(curl -sL https://ci.appveyor.com/api/projects/tidusjar/requestplex/build/$latestversion)
     .log 8 "json: $json"
     jobId=$(grep -Po '(?<="jobId":")([^"]+)' <<<  "$json")


### PR DESCRIPTION
This skips the version check and forces the version specified to be downloaded and installed. This is probably not compatible with https://github.com/Unimatrix0/update_ombi/pull/21 without some tweaking, but I think this one should be a higher priority and changes could be made to https://github.com/Unimatrix0/update_ombi/pull/21 after this is merged (if this is merged).